### PR TITLE
Fix double escaping issue in User Permissions Editor->Save alert()

### DIFF
--- a/Open-ILS/xul/staff_client/server/patron/user_edit.js
+++ b/Open-ILS/xul/staff_client/server/patron/user_edit.js
@@ -130,7 +130,7 @@ function save_user () {
         if (pok.ilsevent) throw pok;
 
         if (pok || wok) {
-            alert($("patronStrings").getFormattedString('staff.patron.user_edit.save_user.user_modified_successfully', [user.usrname(), user.card().barcode(), pok, wok]));
+            alert($("patronStrings").getFormattedString('staff.patron.user_edit.save_user.user_modified_successfully', [user.usrname(), user.card().barcode(), pok, wok]).replace("\\n", "\n"));
         }
 
         init_editor();


### PR DESCRIPTION
getFormattedString(), which uses nsTextFormatter::smprintf, escapes backslashes resulting in the literal display of "\n" in the alert window.

This commit addresses the issue in the same method used in [Open-ILS/xul/staff_client/server/serial/batch_receive.js](https://github.com/evergreen-library-system/Evergreen/blob/0483dc441e97873b48f8f72595cc577bc1ac9015/Open-ILS/xul/staff_client/server/serial/batch_receive.js#L19).

-a
