### PR TITLE
Docs 2.6: Lost Item Billing Min/Max Price Settings

### DIFF
--- a/docs/admin_initial_setup/borrowing_items.txt
+++ b/docs/admin_initial_setup/borrowing_items.txt
@@ -226,6 +226,10 @@ this amount of time, an attempt to check out the item to the patron that it is
 already checked out to will simply renew the circulation. 
 * *Cap Max Fine at Item Price* - This prevents the system from charging more
 than the item price in overdue fines.
+* *Lost Item Billing: New Min/Max Price Settings* - Patrons will be billed
+at least the Min Price and at most the Max price, even if the item's price
+is outside that range. To set a fixed price for all lost items, set min and
+max to the same amount.
 * *Charge fines on overdue circulations when closed* - Normally, fines are not
 charged when a library is closed. When set to True, fines will be charged during
 scheduled closings and normal weekly closed days. 


### PR DESCRIPTION
Add a short description for the new 2.6 feature "Lost Item Billing: New Min/Max Price Settings" to the only section where it seems to fit, and it seems obscure and hard to find. It could be useful to create a new, more prominent section for common Org Unit Settings, possibly organized by category. Sending this via GitHub to test the new Docs workflow.

Signed-off-by: Remington Steed rjs7@calvin.edu
