### PR TITLE
update Patron Search to add DOB

### DIFF
--- a/docs/circulation/circulation_patron_records_web_client.adoc
+++ b/docs/circulation/circulation_patron_records_web_client.adoc
@@ -35,6 +35,9 @@ Next to the _Clear Form_ button there is a button with an arrow pointing down th
 * Postal Code
 * Profile Group
 * Home Library 
+* DOB (date of birth) year
+* DOB month
+* DOB day
 
 You patrons searches may also include patrons marked ``inactive'' if you click on the _Include Inactive?_ checkbox.
 
@@ -47,6 +50,9 @@ image::media/circulation_patron_records-1b_web_client.png[circulation_patron_rec
 * Search one field or combine fields for more precise results.  
 * Truncate search terms for more search results.
 * Search ignores punctuation such as diacritics, apostrophes, hyphens and commas.
+* Searching by Date of Birth: Year searches are "contains" searches. E.g. year "15" matches 2015, 1915, 1599, etc. For exact matches use the full 4-digit year. Day and month values are exact matches. E.g. month "1" (or "01") matches January, "12" matches December.
+
+
 ===================
 
 Once you have located the desired patron, click on the entry row for this patron in


### PR DESCRIPTION
Patron Search now includes DOB y/m/d -- this file changes adds those fields to the list of searches and adds tips for search syntax for DOB
image::media/circulation_patron_records-1b_web_client.png[circulation_patron_records 1b] needs to be updated to also display the DOB search fields. an updated version of this image with edited filename (1c instead of 1b) is available in https://github.com/katiegmartin/Evergreen/tree/master/docs/media as circulation_patron_records 1c