### PR TITLE
Docs: Add alt text to images in borrowing_items.adoc

### DIFF
--- a/docs/modules/admin_initial_setup/pages/borrowing_items.adoc
+++ b/docs/modules/admin_initial_setup/pages/borrowing_items.adoc
@@ -72,7 +72,7 @@ identify the maximum renewals that can be placed on an item.
 You can find Circulation Duration Rules by navigating to *Administration
 -> Server Administration -> Circulation Duration Rules*. 
 
-image::borrowing_items/circ_duration_rules.jpg[]
+image::borrowing_items/circ_duration_rules.jpg["The circ duration rules screen is a table with columns called name, max_renewals, shrt, normal, and extended"]
 
 *Recurring fine* describes the amount assessed for daily and hourly fines as
 well as fines set for other regular intervals. You can also identify any grace
@@ -81,7 +81,7 @@ periods that should be applied before the fine starts accruing.
 You can find Recurring Fine Rules by navigating to *Administration -> Server
 Administration -> Circulation Recurring Fine Rules*.
 
-image::borrowing_items/circ_recurring_fine_rules.jpg[]
+image::borrowing_items/circ_recurring_fine_rules.jpg["The recurring fine rules screen is a table with columns called name, recurrence interval, low, normal, high, and grace period"]
 
 *Max fine* describes the maximum amount of fines that will be assessed for a
 specific circulation. Set the *Is Percent* field to True if the maximum fine
@@ -90,7 +90,7 @@ should be a percentage of the item's price.
 You can find Circ Max Fine Rules by navigating to *Administration -> Server
 Administration -> Circulation Max Fine Rules*.
 
-image::borrowing_items/circ_max_fine_rules.jpg[]
+image::borrowing_items/circ_max_fine_rules.jpg["The Circ Max Fine Rules screen is a table with columns called Rule Name, Max Fine Amount, and Is Percent"]
 
 These rules generally cause the most variation between organizational units.
 


### PR DESCRIPTION
Missing alt text was identified by [vale](https://vale.sh/)