### PR TITLE
Docs: Long Overdue Reactor Info

### DIFF
--- a/docs/modules/circulation/pages/circulating_items_web_client.adoc
+++ b/docs/modules/circulation/pages/circulating_items_web_client.adoc
@@ -904,6 +904,9 @@ Evergreen has two sample Notification/Action Triggers that are related to markin
 
 ** 6 Month Long Overdue Notice—will send patron notification that an item has been marked long overdue on their account
 
+[TIP]
+LOST reactors for action triggers also react to Long Overdues.  This means that Long Overdue cannot be activated while Mark Lost, for example, is activated.  To use Long Overdue, you would need to deactivate Mark Lost.
+
 [[longoverdue_library_settings]]
 *Library Settings* 
 


### PR DESCRIPTION
Adding in a note that Long Overdues need the LOST reactor.