### PR TITLE
Add tt2 syntax highlighting and fix various documentation issues

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -14,7 +14,7 @@ nav:
 - modules/serials/nav.adoc
 - modules/circulation/nav.adoc
 - modules/reports/nav.adoc
-- modules/course/nav.adoc
+# - modules/course/nav.adoc
 - modules/opac/nav.adoc
 - modules/course_materials/nav.adoc
 - modules/integrations/nav.adoc

--- a/docs/modules/admin/pages/apache_rewrite_tricks.adoc
+++ b/docs/modules/admin/pages/apache_rewrite_tricks.adoc
@@ -44,7 +44,7 @@ Variables. From within Template Toolkit templates you can access environment
 variables with the ENV object.
 
 .Template Toolkit ENV example, link library name/url if set
-[source,html]
+[source,tt2]
 ----
 [% IF ENV.eglibname && ENV.egliburl %]<a href="[% ENV.egliburl %]">[% ENV.eglibname %]</a>[% END %]
 ----

--- a/docs/modules/admin/pages/librarysettings.adoc
+++ b/docs/modules/admin/pages/librarysettings.adoc
@@ -6,7 +6,7 @@
 
 With the *Library Settings Editor* one can optionally customize
 Evergreen's behavior for a particular library or library system. For
-descriptions of available settings see the xref:#settings_overview[Settings Overview] table below.
+descriptions of available settings see the xref:#_settings_overview[Settings Overview] table below.
 
 == Editing Library Settings ==
 
@@ -32,7 +32,7 @@ You can revert back to an old value by clicking *revert*.
 image::library_settings/history_lib_setting.png[Library Setting History]
 
 NOTE: Please note that different settings may require different data
-formats, which are listed in the xref:#settings_overview[Settings Overview] table. Refer to the xref:#data_types[Data Types] table at the
+formats, which are listed in the xref:#_settings_overview[Settings Overview] table. Refer to the xref:#_data_types[Data Types] table at the
 bottom of this page for more information.
 
 == Exporting/Importing Library Settings ==
@@ -53,7 +53,6 @@ contents. Click *Paste* in the pop-up window. Click *Submit*.
 +
 image::library_settings/import_lib_settings.png[Importing Library Settings]
 
-[#settings_overview]
 == Settings Overview ==
 
 The settings are grouped together in separate tables based on functions
@@ -61,7 +60,7 @@ and modules, which are affected by the setting. They are in the same
 sequence as you see in the staff client. Each table describes the
 available settings in the group and shows which can be changed on a
 per-library basis. At the bottom is the table with a list of
- xref:#data_types[data types] with details about acceptable settings
+ xref:#_data_types[data types] with details about acceptable settings
 values.
 
 Jump to a specific table:
@@ -113,7 +112,7 @@ Jump to a specific table:
 |Upload Merge on Single Match by Default|Merge records on single match by default during ACQ file upload|True/False|
 |========
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("Booking", "Library Settings Editor")))
 ((("Cataloging", "Library Settings Editor")))
@@ -141,7 +140,7 @@ Jump to a specific table:
 |Spine label maximum lines|Set the default maximum number of lines for spine labels.|Number|
 |======================
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("Circulation", "Library Settings Editor")))
 
@@ -215,7 +214,7 @@ Jump to a specific table:
 |Warn when patron account is about to expire|If set, the staff client displays a warning this number of days before the expiry of a patron account. Value is in number of days.|Duration|
 |===========
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("Credit Card Processing", "Library Settings Editor")))
 
@@ -246,7 +245,7 @@ Jump to a specific table:
 |Stripe secret key|Secret API key from stripe.|Text|
 |======================
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("Finances", "Library Settings Editor")))
 
@@ -277,7 +276,7 @@ Jump to a specific table:
 |Void overdue fines when items are marked lost|If true overdue fines are voided when an item is marked lost|True/False|
 |========
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("GUI", "Library Settings Editor")))
 ((("Graphic User Interface", "Library Settings Editor")))
@@ -317,11 +316,11 @@ Jump to a specific table:
 !Record in-house use: # of uses threshold for Are You Sure? dialog.!In the Record In-House Use interface, a submission attempt will warn if the # of uses field exceeds the value of this setting.!Number!
 !Record In-House Use: Maximum # of uses allowed per entry.!The # of uses entry in the Record In-House Use interface may not exceed the value of this setting.!Number!
 !Regex for barcodes on patron registration!The Regular Expression for validation on barcodes in patron registration.!Regular Expression!
-!Regex for Day_phone field on patron registration! The Regular Expression for validation on the Day_phone field in patron registration. Note: The first capture group will be used for the "last 4 digits of phone number" as patron password feature, if enabled. Ex: "+[2-9]\d{2}-\d{3}-(\d{4})( x\d+)?+" will ignore the extension on a NANP number.!Regular expression!
+!Regex for Day_phone field on patron registration! The Regular Expression for validation on the Day_phone field in patron registration. Note: The first capture group will be used for the "last 4 digits of phone number" as patron password feature, if enabled. Ex: `+[2-9]\d\{2\}-\d\{3\}-(\d\{4\})( x\d+)?+` will ignore the extension on a NANP number.!Regular expression!
 !Regex for Email field on patron registration!The Regular Expression on validation on the Email field in patron registration.!Regular expression!
 !Regex for Evening-phone on patron registration!The Regular Expression on validation on the Evening-phone field in patron registration.!Regular expression!
 !Regex for Other-phone on patron registration!The Regular Expression on validation on the Other-phone field in patron registration.!Regular expression!
-!Regex for phone fields on patron registration!The Regular Expression on validation on phone fields in patron registration. Applies to all phone fields without their own setting.!Regular expression!`+^(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:\(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?([2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?([0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$+` is a US phone number
+!Regex for phone fields on patron registration!The Regular Expression on validation on phone fields in patron registration. Applies to all phone fields without their own setting.!Regular expression!`+^(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:\(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?([2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]\{2\})\s*(?:[.-]\s*)?([0-9]\{4\})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$+` is a US phone number
 !Regex for Postal Code field on patron registration!The Regular Expression on validation on the Postal Code field in patron registration.!Regular expression!
 !Require at least one address for Patron Registration!Enforces a requirement for having at least one address for a patron during registration. If set to False, you need to delete the empty address before saving the record. If set to True, deletion is not allowed.!True/False!
 !Require XXXXX field on patron registration!The XXXXX field will be required on the patron registration screen.!True/False!XXXXX can be Country, State, Day-phone, Evening-phone, Other-phone, DOB, Email, or Prefix.
@@ -340,7 +339,7 @@ Jump to a specific table:
 !Work Log: maximum patrons logged!Maximum entries for "Most Recently Affected Patrons..." section of the Work Log interface.!Number!
 !===========================
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("Global", "Library Settings Editor")))
 
@@ -357,7 +356,7 @@ Jump to a specific table:
 |Patron username format|Regular expression defining the patron username format, used for patron registration and self-service username changing only|Regular expression|
 |======
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("Holds", "Library Settings Editor")))
 
@@ -399,7 +398,7 @@ For multiple branch libraries
 |Use weight-based hold targeting|Use library weight based hold targeting|True/False|
 |=====
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("Library", "Library Settings Editor")))
 
@@ -421,7 +420,7 @@ The default is at midnight each night for items with "Reshelving" status for ove
 |Telephony: Arbitrary line(s) to include in each notice callfile|This overrides lines from opensrf.xml. Line(s) must be valid for your target server and platform (e.g. Asterisk 1.4).|Text|
 |=======
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("OPAC", "Library Settings Editor")))
 
@@ -448,7 +447,7 @@ The default is at midnight each night for items with "Reshelving" status for ove
 |Warn patrons when adding to a temporary book list|Present a warning dialogue when a patron adds a book to the temporary book list.|True/False|
 |====
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("Offline", "Library Settings Editor")))
 ((("Program", "Library Settings Editor")))
@@ -466,7 +465,7 @@ The default is at midnight each night for items with "Reshelving" status for ove
 |Sending email address for patron notices|This email address is for automatically generated patron notices (e.g. email overdues, email holds notification).  It is good practice to set up a generic account, like info@nameofyourlibrary.org, so that one person’s individual email inbox doesn’t get cluttered with emails that were not delivered.|Text|
 |===================
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("Receipt Templates", "Library Settings Editor")))
 ((("SMS Settings", "Library Settings Editor")))
@@ -486,7 +485,7 @@ The default is at midnight each night for items with "Reshelving" status for ove
 |Enable features that send SMS text messages.|Current features that use SMS include hold-ready-for-pickup notifications and a "Send Text" action for call numbers in the OPAC. If this setting is not enabled, the SMS options will not be offered to the user. Unless you are carefully silo-ing patrons and their use of the OPAC, the context org for this setting should be the top org in the org hierarchy, otherwise patrons can trample their user settings when jumping between orgs.|True/False|
 |======================================
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("Security", "Library Settings Editor")))
 
@@ -510,7 +509,7 @@ usernames in addition to barcode. For this setting to work, a barcode format mus
 |Staff login inactivity timeout (in seconds)|Number of seconds of inactivity before staff client prompts for login and password.|Number|
 |========
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("Self Check", "Library Settings Editor")))
 
@@ -535,7 +534,7 @@ usernames in addition to barcode. For this setting to work, a barcode format mus
 |Number of seconds to wait between URL test attempts|Throttling mechanism for batch URL verification runs. Each running process will wait this number of seconds after a URL test before performing the next.|Duration|
 |=====================
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
 ((("Vandelay", "Library Settings Editor")))
 
@@ -553,9 +552,8 @@ usernames in addition to barcode. For this setting to work, a barcode format mus
 |Vandelay Generate Default Call Numbers|Auto-generate default item call numbers when no item call number is present|True/False|These are pulled from the MARC Record.
 |========
 
-<<settings_overview,Return to Settings Overview>>
+xref:#_settings_overview[Return to Settings Overview]
 
-[#data_types]
 === Data Types ===
 
 ((("Data Types", "Library Settings Editor")))

--- a/docs/modules/admin/pages/template_toolkit.adoc
+++ b/docs/modules/admin/pages/template_toolkit.adoc
@@ -71,7 +71,7 @@ template files. For example, the `home.tt2` template currently involves a
 number of other template files to generate a single HTML file:
 
 .Example Template Toolkit file: opac/home.tt2
-[source, html]
+[source, tt2]
 ------------------------------------------------------------------------------
 [%  PROCESS "opac/parts/header.tt2";
     WRAPPER "opac/parts/base.tt2";
@@ -231,7 +231,7 @@ bash$ vim /openils/var/templates_BR1/opac/parts/topnav_links.tt2
 Finally, we edit the link text in `opac/parts/header.tt2`.
 
 .Content of the opac/parts/header.tt2 file
-[source,html]
+[source,tt2]
 ------------------------------------------------------------------------------
 <div id="gold-links-holder">
     <div id="gold-links">

--- a/docs/modules/admin_initial_setup/pages/designing_your_catalog.adoc
+++ b/docs/modules/admin_initial_setup/pages/designing_your_catalog.adoc
@@ -48,6 +48,7 @@ template files. For example, the _home.tt2_ template currently involves a number
 of other template files to generate a single HTML file.
 
 Example Template Toolkit file: _opac/home.tt2_.
+[source,tt2]
 ----
 [%  PROCESS "opac/parts/header.tt2";
     WRAPPER "opac/parts/base.tt2";
@@ -166,6 +167,7 @@ bash$ vim /openils/var/templates_custom/opac/parts/topnav_links.tt2
 Finally, edit the link text in _opac/parts/header.tt2_. Content of the
 _opac/parts/header.tt2_ file.
 
+[source, tt2]
 ----
 <div id="gold-links-holder">
     <div id="gold-links">
@@ -261,6 +263,7 @@ template variable for the MARC field to display.
 For example, to display the date of publication code you created in the
 _misc_util.tt2_ file, add these lines:
 
+[source, tt2]
 ----
 [% IF attrs.pubdate; %]
     <span itemprop="datePublished">[% attrs.pubdate | html; %]</span>
@@ -364,12 +367,14 @@ Libraries with same-day circulations may want their patrons to be able to view
 the due *time* as well as due date when they log in to their OPAC account.  To
 accomplish this, go to _opac/myopac/circs.tt2_.  Find the line that reads:
 
+[source, tt2]
 ----
 [% date.format(due_date, DATE_FORMAT) %]
 ----
 
 Replace it with:
 
+[source, tt2]
 ----
 [% date.format(due_date, '%D %I:%M %p') %]
 ----

--- a/docs/modules/opac/pages/new_skin_customizations.adoc
+++ b/docs/modules/opac/pages/new_skin_customizations.adoc
@@ -125,6 +125,7 @@ Search > Numeric search. If you wanted to add a bib call number search option,
 which is different from the item copy call number; you would add the following
 code to `numeric.tt2`.
 +
+[source, tt2]
 ------------------------------------------------------------------------------
 <option value="identifier|bibcn">[% l('Bib Call Number') %]</option>  
 ------------------------------------------------------------------------------

--- a/docs/modules/reports/pages/reporter_cloning_shared_templates.adoc
+++ b/docs/modules/reports/pages/reporter_cloning_shared_templates.adoc
@@ -76,8 +76,7 @@ select *Clone Template*.
 . In the _Clone Template_ modal that opens enter a name for your template. 
 By default, the system will take the original name and add _(Clone)_ to the end.
 . Select *Confirm*.
-. The template editor will open. For information on modifying templates, see 
-the section on xref:reporter_modifying_templates.adoc[Modifying Templates].
+. The template editor will open.
 . Update the template name and/or template description if desired.
 . Select *Save*. Once a template is saved it is not possible to edit the template.
  To make changes, clone a template and change the clone.

--- a/docs/modules/reports/pages/reporter_template_terminology.adoc
+++ b/docs/modules/reports/pages/reporter_template_terminology.adoc
@@ -17,36 +17,16 @@ is associated with a data type. This indicates what kind of information is store
 [options="header"]
 |===
 |Data Type |Description |Notes
-|Boolean |Contains either "true" or "false". |Examples in Evergreen: "deleted"
- in item/patron record, "circulate?" in item record.
-|ID |Unique number assigned by the database to identify a record |IDs look like
- numbers, but the ID 
-data type is treated specially by the software for determining how tables are l
-inked. ID is a good candidate field for counting records.
-|Integer |A number like 1, 2, 3. |Examples in Evergreen: "remaining renewal count"
- in circulation record, "claimed returned count" in patron record.
-|Interval |Time intervals, such as "2 weeks" and "6 months" |Examples in 
-Evergreen: "loan duration" and "grace period" in circulation record,
-|Link |It is similar to the id data type. It is the id of a record in another
- table. |Examples in Evergreen: "user id" and "item id" in a circulation record.
- Link outputs a number that is a meaningful reference for the database but not 
- of much use to a human user. You will usually want to drill further down the 
- tree in the Sources pane and select fields from the linked table. However, in 
- some instances you might want to use a link field. For example, to count the 
- number of patrons who borrowed items, you could do a count on the "user id" in
- the circulation record.
-|Money |Monetary amount |Examples in Evergreen: "price" in item record, "billing
- amount" in billing record.
-|Org_unit |Organizational unit. It is a number. It acts like a link data type. |
-In Evergreen, libraries are organizational units. In some contexts, they are o
-rganized into a tree structure with consortium, library systems, and branches for 
-library systems. To filter on a library, make sure you choose the field having 
-org_unit data type. To display a library, it is a better option to drill down 
-to the org unit record to display the "name" of it.
-|Text |Text field. Usually it takes whatever is typed into the field. |Examples:
- "call number label" in call number record, "patron's names".
-|Timestamp |A very detailed time such as 2018-11-25 17:54:26-07 |Example: checkout
- time in circulation record, last status date in item record.
+|Boolean |Contains either "true" or "false". |Examples in Evergreen: "deleted" in item/patron record, "circulate?" in item record.
+|ID |Unique number assigned by the database to identify a record. |IDs look like numbers, but the ID data type is treated specially by the software for determining how tables are linked. ID is a good candidate field for counting records.
+|Integer |A number like 1, 2, 3. |Examples in Evergreen: "remaining renewal count" in circulation record, "claimed returned count" in patron record.
+|Interval |Time intervals, such as "2 weeks" and "6 months". |Examples in 
+Evergreen: "loan duration" and "grace period" in circulation record.
+|Link |It is similar to the ID data type. It is the ID of a record in another table. |Examples in Evergreen: "user id" and "item id" in a circulation record. Link outputs a number that is a meaningful reference for the database but not of much use to a human user. You will usually want to drill further down the tree in the Sources pane and select fields from the linked table. However, in some instances you might want to use a link field. For example, to count the number of patrons who borrowed items, you could do a count on the "user id" in the circulation record.
+|Money |Monetary amount. |Examples in Evergreen: "price" in item record, "billing amount" in billing record.
+|Org_unit |Organizational unit. It is a number. It acts like a link data type. |In Evergreen, libraries are organizational units. In some contexts, they are organized into a tree structure with consortium, library systems, and branches for library systems. To filter on a library, make sure you choose the field having org_unit data type. To display a library, it is a better option to drill down to the org unit record to display the "name" of it.
+|Text |Text field. Usually it takes whatever is typed into the field. |Examples: "call number label" in call number record, "patron's names".
+|Timestamp |A very detailed time such as 2018-11-25 17:54:26-07. |Example: checkout time in circulation record, last status date in item record.
 |===
 
 [[report_field_transforms]]
@@ -63,41 +43,17 @@ Transforms determine how data is processed when it is retrieved from the databas
 [options="header"]
 |===
 |Transform |Applicable Data Types |Description | Notes
-|Raw Data |All Data Types |To display the data exactly as it is stored in the 
-database. | Most commonly used transform .
-|Date |Timestamps | This transform presents a timestamp as a human-readable 
-date in yyyy-mm-dd format. |For example, timestamp 2018-11-25 17:54:26-07 will
- be displayed as 2018-11-25. 
-|Year \+ Month |Timestamps | Presents a timestamp as the year and month in yyyy-mm
- format. |For example, 2018-11-25 17:54:26-07 will be displayed as 2018-11. If 
- filtering on a timestamp transformed to Year + Month, all days in the calendar 
- month are included.
-|Upper Case |Text | Transforms text to all upper case. |
-|Lower Case |Text | Transforms text to all lower case. |
-|Substring |Text | This transform can be applied to filters, not display fields.
- It matches the given value with a continuous string of characters in the field.
- |For example, if a given value is "123" and the match is with a call number 
- field, call numbers like "123.34", "ANF 123.34", "JNF 233.123", etc. will be in
- the result list.
-|First Continuous Non-space string |Text | The first word (or string of numbers 
-and/or characters until the first spacing) in a field is returned by this transform.
- |For example, this transform will return "E" from text "E DOR", "E 123", etc. 
-|Count |Text, Integer, ID, Money, Timestamp, Org_unit | This transform counts the
- records found. |Though you can count by any field, very often id field is used. 
-|Count Distinct |Text, Integer, ID, Money, Timestamp, Org_unit | This transform 
-counts the number of records  with unique value in the field. If two records have
- the same value in the field, they will be counted once only. |A typical example
- of using Count Distinct is counting the number of active patrons who borrowed 
- items at a library. Each patron can be counted once only but they may borrow 
- multiple items. Transforming the patron id in circulation record with Count 
- Distinct will result in the required number. Since each patron has a unique id,
- they will be counted once only. 
-|Max |Text, Integer, Money, and Timestamp | It compares the values in the field 
-of all result records and then returns the one record with the highest value. 
-For timestamp, the highest value meansthe latest date. |For example, if a checkout
- date is transformed by Max, the returned date is the last checkout date.
-|Min |Text, Integer, Money, and Timestamp | It works the same way as Max except 
-that it returns the lowest value. |
+|Raw Data |All Data Types |To display the data exactly as it is stored in the database. |Most commonly used transform.
+|Date |Timestamps |This transform presents a timestamp as a human-readable date in yyyy-mm-dd format. |For example, timestamp 2018-11-25 17:54:26-07 will be displayed as 2018-11-25.
+|Year \+ Month |Timestamps |Presents a timestamp as the year and month in yyyy-mm format. |For example, 2018-11-25 17:54:26-07 will be displayed as 2018-11. If filtering on a timestamp transformed to Year + Month, all days in the calendar month are included.
+|Upper Case |Text |Transforms text to all upper case. |
+|Lower Case |Text |Transforms text to all lower case. |
+|Substring |Text |This transform can be applied to filters, not display fields. It matches the given value with a continuous string of characters in the field. |For example, if a given value is "123" and the match is with a call number field, call numbers like "123.34", "ANF 123.34", "JNF 233.123", etc. will be in the result list.
+|First Continuous Non-space string |Text |The first word (or string of numbers and/or characters until the first spacing) in a field is returned by this transform. |For example, this transform will return "E" from text "E DOR", "E 123", etc.
+|Count |Text, Integer, ID, Money, Timestamp, Org_unit |This transform counts the records found. |Though you can count by any field, very often ID field is used.
+|Count Distinct |Text, Integer, ID, Money, Timestamp, Org_unit |This transform counts the number of records with unique value in the field. If two records have the same value in the field, they will be counted once only. |A typical example of using Count Distinct is counting the number of active patrons who borrowed items at a library. Each patron can be counted once only but they may borrow multiple items. Transforming the patron ID in circulation record with Count Distinct will result in the required number. Since each patron has a unique ID, they will be counted once only.
+|Max |Text, Integer, Money, and Timestamp |It compares the values in the field of all result records and then returns the one record with the highest value. For timestamp, the highest value means the latest date. |For example, if a checkout date is transformed by Max, the returned date is the last checkout date.
+|Min |Text, Integer, Money, and Timestamp |It works the same way as Max except that it returns the lowest value. |
 |===
 
 [[report_operators]]
@@ -111,46 +67,20 @@ be included in the result. The record is included when the comparison returns
 "TRUE". The possible ways of comparing data are related to data type and data 
 transforms. The available operators are:
 
-[options="header"]
+[options="header",cols="4*"]
 |===
-|Operator |Description |Notes
-|Equals | Compares two operands and returns TRUE if they are exactly the same. |
-|Contains Matching Substring | This operator checks if any part of the field 
-matches the given parameter. |It is case-sensitive.
-|Contains Matching Substring (Ignore Case) | This operator is identical to 
-Contains Matching Substring, except it is not case-sensitive. |
-|Greater Than | This operator returns TRUE if a field is greater than your 
-parameter. | For text fields, the string is compared character by character in
- accordance with the general rule that numerical characters are smaller than 
- alphabetical characters and uppercase alphabeticals are smaller than lowercase
- alphabeticals For timestamps, "Greater Than" can be thought of as "later than"
- or "after".
-|Greater than or equal to |This operator returns TRUE if a field is greater than
- or equal to your parameter. | For text fields, the string is compared character
- by character in accordance with the general rule that numerical characters are
- smaller than alphabetical characters and uppercase alphabeticals are smaller 
- than lower case alphabeticals. For timestamps, "Greater Than or equal to" can
- be thought of as "later than or equal to" or "after or equal to".
-|Less Than | This operator returns TRUE if a field is less than, lower than, 
-earlier than, or smaller than your parameter. |
-|In List| It is similar to Equals, except it allows you to specify multiple 
-parameters and returns "TRUE" if the field is equal to any one of the given 
-values. |
-|Not In List | It is the opposite of In List. Multiple parameters can be specified.
- TRUE will be returned only when none of the parameters is matched with the value 
- in the field. |
-|Between | Two parameters are required by this operator. TRUE is returned when the 
-field value is Greater Than or Equal to the smaller given value and Less Than or 
-Equal to the bigger given value. | The smaller parameter should always come first 
-when filling in a filter with this operator. For example: between 3 and 5 is 
-correct. Between 5 and 3 will return FALSE on the Reports interface. For timestamp,
- the earlier date always comes first.
-|Is NULL | Returns TRUE for fields that contain no data.| For example, an overdue
- report will include a filter for Check In Date/Time is NULL as an item is no 
- longer overdue if there is a value for Check In Date/Time.
-|Is NULL or Blank | Returns TRUE for fields that contain no data or blank string.
- | For most intents and purposes, this operator should be used when there is no 
- visible value in the field. |
+|Operator |Description |Notes |Example
+|Equals |Compares two operands and returns TRUE if they are exactly the same. | |Field value = "123".
+|Contains Matching Substring |This operator checks if any part of the field matches the given parameter. |It is case-sensitive. |Field value contains "abc".
+|Contains Matching Substring (Ignore Case) |This operator is identical to Contains Matching Substring, except it is not case-sensitive. | |Field value contains "ABC" (case-insensitive).
+|Greater Than |This operator returns TRUE if a field is greater than your parameter. |For text fields, the string is compared character by character in accordance with the general rule that numerical characters are smaller than alphabetical characters and uppercase alphabeticals are smaller than lowercase alphabeticals. For timestamps, "Greater Than" can be thought of as "later than" or "after". |Field value > "2023-01-01".
+|Greater than or equal to |This operator returns TRUE if a field is greater than or equal to your parameter. |For text fields, the string is compared character by character in accordance with the general rule that numerical characters are smaller than alphabetical characters and uppercase alphabeticals are smaller than lowercase alphabeticals. For timestamps, "Greater Than or equal to" can be thought of as "later than or equal to" or "after or equal to". |Field value >= "2023-01-01".
+|Less Than |This operator returns TRUE if a field is less than, lower than, earlier than, or smaller than your parameter. | |Field value < "2023-01-01".
+|In List |It is similar to Equals, except it allows you to specify multiple parameters and returns "TRUE" if the field is equal to any one of the given values. | |Field value in ("123", "456").
+|Not In List |It is the opposite of In List. Multiple parameters can be specified. TRUE will be returned only when none of the parameters is matched with the value in the field. | |Field value not in ("123", "456").
+|Between |Two parameters are required by this operator. TRUE is returned when the field value is Greater Than or Equal to the smaller given value and Less Than or Equal to the bigger given value. |The smaller parameter should always come first when filling in a filter with this operator. For example: between 3 and 5 is correct. Between 5 and 3 will return FALSE on the Reports interface. For timestamp, the earlier date always comes first. |Field value between "2023-01-01" and "2023-12-31".
+|Is NULL |Returns TRUE for fields that contain no data. |For example, an overdue report will include a filter for Check In Date/Time is NULL as an item is no longer overdue if there is a value for Check In Date/Time. |Field value is NULL.
+|Is NULL or Blank |Returns TRUE for fields that contain no data or blank string. |For most intents and purposes, this operator should be used when there is no visible value in the field. |Field value is NULL or blank.
 |===
 
 [[report_filter_values]]

--- a/docs/modules/reports/pages/reports_security_idl.adoc
+++ b/docs/modules/reports/pages/reports_security_idl.adoc
@@ -1,5 +1,5 @@
-= Reports Security IDL Configuration =
-:toc:
+= Reports Security IDL
+== Introduction
 
 The new Report Security functionality is primarily configured through the addition of XML attributes to elements in the Fieldmapper XML file, fm_IDL.xml.  These new attributes fall into three categories:
 
@@ -10,7 +10,7 @@ The new Report Security functionality is primarily configured through the additi
 
 These attributes, explained below, are defined within a new XML namespace with the URI `http://open-ils.org/spec/opensrf/IDL/reporter/v1/security` , and the common namespace prefix of `repsec` .  An accompanying XSD is provided to confirm that the locations and values of the attributes, when supplied, do not fall outside their defined scope and that the fm_IDL.xml file remains both well-formed and valid.
 
-= Field value redaction =
+== Field value redaction ==
 
 Fields used in the SELECT and ORDER BY SQL clauses can be redacted, either outputting NULL or, optionally, a data type compatible alternate literal value.  This is configured through the addition of several XML attributes to the fields to which redaction should be applied.
 


### PR DESCRIPTION
This PR was intended only to add `tt2` syntax highlighting to relevant code blocks in the documentation, but the build was throwing several errors, so I decided to address those as well. The build should now have no warnings.

- Added `tt2` syntax highlighting to appropriate code blocks across multiple files.
- Escaped `{2}` and `{4}` in regex string examples in the library settings document to prevent Antora from interpreting them as attributes.
- Left a commented-out reference to `modules/course/nav.adoc` in `antora.yml` for further review, as the file does not exist. **_Does anyone know what happened here?_**
- Fixed incomplete rows in tables within the reporter template terminology page.
- Corrected duplicate level 1 headings in the reports security IDL document.

Release-Note: Added `tt2` syntax highlighting to appropriate code blocks across multiple files.  

Signed-off-by: IanSkelskey <ianskelskey@gmail.com>
